### PR TITLE
Output .tar.bz2 artifacts

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,4 +3,5 @@ github:
   tooling_branch_name: main
 conda_forge_output_validation: true
 conda_build:
-  pkg_format: '2'
+  pkg_format: 2    # makes .conda artifacts
+  pkg_format: None # makes .tar.bz2 artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: pytensor-base


### PR DESCRIPTION
This configures the feedstock to output `.tar.bz2` artifacts in addition to `.conda` artifacts.

We need this for cachine to work in CI pipeliens.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
