### PR TITLE
Revert "Output .tar.bz2 artifacts"

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,7 +4,6 @@ github:
 conda_forge_output_validation: true
 conda_build:
   pkg_format: 2    # makes .conda artifacts
-  pkg_format: None # makes .tar.bz2 artifacts
 build_platform:
   osx_arm64: osx_64
 test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: pytensor-base


### PR DESCRIPTION
This reverts commit ed10febcdf8a6c868cd0bd1acc8732046ad12bc9.

Closes #8 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
