### PR TITLE
Explicitly skip building aarch64 with pypy 3.8

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,74 +8,69 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.21python3.10.____cpython:
-        CONFIG: linux_64_numpy1.21python3.10.____cpython
+      linux_64_numpy1.21python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.21python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.21python3.10.____cpython
-      linux_64_numpy1.21python3.8.____73_pypy:
-        CONFIG: linux_64_numpy1.21python3.8.____73_pypy
+        SHORT_CONFIG: linux_64_numpy1.21python3.10.____cp_hc201f56a3b
+      linux_64_numpy1.21python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_64_numpy1.21python3.8.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.21python3.8.____73_pypy
-      linux_64_numpy1.21python3.8.____cpython:
-        CONFIG: linux_64_numpy1.21python3.8.____cpython
+        SHORT_CONFIG: linux_64_numpy1.21python3.8.____73__hba74da1319
+      linux_64_numpy1.21python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.21python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.21python3.8.____cpython
-      linux_64_numpy1.21python3.9.____73_pypy:
-        CONFIG: linux_64_numpy1.21python3.9.____73_pypy
+        SHORT_CONFIG: linux_64_numpy1.21python3.8.____cpy_h498dea91b8
+      linux_64_numpy1.21python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_64_numpy1.21python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.21python3.9.____73_pypy
-      linux_64_numpy1.21python3.9.____cpython:
-        CONFIG: linux_64_numpy1.21python3.9.____cpython
+        SHORT_CONFIG: linux_64_numpy1.21python3.9.____73__h75c756eb1d
+      linux_64_numpy1.21python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.21python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.21python3.9.____cpython
-      linux_64_numpy1.23python3.11.____cpython:
-        CONFIG: linux_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: linux_64_numpy1.21python3.9.____cpy_ha12170798e
+      linux_64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.23python3.11.____cpython
-      linux_aarch64_numpy1.21python3.10.____cpython:
-        CONFIG: linux_aarch64_numpy1.21python3.10.____cpython
+        SHORT_CONFIG: linux_64_numpy1.23python3.11.____cp_h28e7358e74
+      linux_aarch64_numpy1.21python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.21python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.21python3.10.____cpython
-      linux_aarch64_numpy1.21python3.8.____73_pypy:
-        CONFIG: linux_aarch64_numpy1.21python3.8.____73_pypy
+        SHORT_CONFIG: linux_aarch64_numpy1.21python3.10.__h261ce13961
+      linux_aarch64_numpy1.21python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_numpy1.21python3.8.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.21python3.8.____73_pypy
-      linux_aarch64_numpy1.21python3.8.____cpython:
-        CONFIG: linux_aarch64_numpy1.21python3.8.____cpython
+        SHORT_CONFIG: linux_aarch64_numpy1.21python3.8.___h7f80b49e9d
+      linux_aarch64_numpy1.21python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.21python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.21python3.8.____cpython
-      linux_aarch64_numpy1.21python3.9.____73_pypy:
-        CONFIG: linux_aarch64_numpy1.21python3.9.____73_pypy
+        SHORT_CONFIG: linux_aarch64_numpy1.21python3.8.___h51b838ff85
+      linux_aarch64_numpy1.21python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_numpy1.21python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.21python3.9.____73_pypy
-      linux_aarch64_numpy1.21python3.9.____cpython:
-        CONFIG: linux_aarch64_numpy1.21python3.9.____cpython
+        SHORT_CONFIG: linux_aarch64_numpy1.21python3.9.___hfc5e3a59e6
+      linux_aarch64_numpy1.21python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.21python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.21python3.9.____cpython
-      linux_aarch64_numpy1.23python3.11.____cpython:
-        CONFIG: linux_aarch64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: linux_aarch64_numpy1.21python3.9.___h9f35eee955
+      linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: linux_aarch64_numpy1.23python3.11.__hd10399580a
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,30 +8,30 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.21python3.10.____cpython:
-        CONFIG: osx_64_numpy1.21python3.10.____cpython
+      osx_64_numpy1.21python3.10.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.21python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.21python3.10.____cpython
-      osx_64_numpy1.21python3.8.____73_pypy:
-        CONFIG: osx_64_numpy1.21python3.8.____73_pypy
+        SHORT_CONFIG: osx_64_numpy1.21python3.10.____cpyt_h16fdaa3d33
+      osx_64_numpy1.21python3.8.____73_pypypython_implpypy:
+        CONFIG: osx_64_numpy1.21python3.8.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.21python3.8.____73_pypy
-      osx_64_numpy1.21python3.8.____cpython:
-        CONFIG: osx_64_numpy1.21python3.8.____cpython
+        SHORT_CONFIG: osx_64_numpy1.21python3.8.____73_py_h9b585130ac
+      osx_64_numpy1.21python3.8.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.21python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.21python3.8.____cpython
-      osx_64_numpy1.21python3.9.____73_pypy:
-        CONFIG: osx_64_numpy1.21python3.9.____73_pypy
+        SHORT_CONFIG: osx_64_numpy1.21python3.8.____cpyth_h2eef7b0c05
+      osx_64_numpy1.21python3.9.____73_pypypython_implpypy:
+        CONFIG: osx_64_numpy1.21python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.21python3.9.____73_pypy
-      osx_64_numpy1.21python3.9.____cpython:
-        CONFIG: osx_64_numpy1.21python3.9.____cpython
+        SHORT_CONFIG: osx_64_numpy1.21python3.9.____73_py_h3b086d8b76
+      osx_64_numpy1.21python3.9.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.21python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.21python3.9.____cpython
-      osx_64_numpy1.23python3.11.____cpython:
-        CONFIG: osx_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: osx_64_numpy1.21python3.9.____cpyth_hdc4bf1bf80
+      osx_64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: osx_64_numpy1.23python3.11.____cpyt_haf16f790ab
       osx_arm64_numpy1.21python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,30 +8,30 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_numpy1.21python3.10.____cpython:
-        CONFIG: win_64_numpy1.21python3.10.____cpython
+      win_64_numpy1.21python3.10.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.21python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.21python3.10.____cpython
-      win_64_numpy1.21python3.8.____73_pypy:
-        CONFIG: win_64_numpy1.21python3.8.____73_pypy
+        SHORT_CONFIG: win_64_numpy1.21python3.10.____cpyt_hb07ed7ccda
+      win_64_numpy1.21python3.8.____73_pypypython_implpypy:
+        CONFIG: win_64_numpy1.21python3.8.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.21python3.8.____73_pypy
-      win_64_numpy1.21python3.8.____cpython:
-        CONFIG: win_64_numpy1.21python3.8.____cpython
+        SHORT_CONFIG: win_64_numpy1.21python3.8.____73_py_heaf210a126
+      win_64_numpy1.21python3.8.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.21python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.21python3.8.____cpython
-      win_64_numpy1.21python3.9.____73_pypy:
-        CONFIG: win_64_numpy1.21python3.9.____73_pypy
+        SHORT_CONFIG: win_64_numpy1.21python3.8.____cpyth_h58e966f8a4
+      win_64_numpy1.21python3.9.____73_pypypython_implpypy:
+        CONFIG: win_64_numpy1.21python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.21python3.9.____73_pypy
-      win_64_numpy1.21python3.9.____cpython:
-        CONFIG: win_64_numpy1.21python3.9.____cpython
+        SHORT_CONFIG: win_64_numpy1.21python3.9.____73_py_h487ae0b195
+      win_64_numpy1.21python3.9.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.21python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.21python3.9.____cpython
-      win_64_numpy1.23python3.11.____cpython:
-        CONFIG: win_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: win_64_numpy1.21python3.9.____cpyth_h1ac5a94a9d
+      win_64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: win_64_numpy1.23python3.11.____cpyt_hfdca1d6b56
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,17 +15,20 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.23'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -25,11 +21,14 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -1,15 +1,19 @@
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
-m2w64_c_compiler:
-- m2w64-toolchain
-m2w64_cxx_compiler:
-- m2w64-toolchain
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -18,8 +22,13 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- win-64
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -1,15 +1,19 @@
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
-m2w64_c_compiler:
-- m2w64-toolchain
-m2w64_cxx_compiler:
-- m2w64-toolchain
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -18,8 +22,13 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
-- win-64
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -1,15 +1,19 @@
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
-m2w64_c_compiler:
-- m2w64-toolchain
-m2w64_cxx_compiler:
-- m2w64-toolchain
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -18,8 +22,13 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- win-64
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,17 +15,20 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.21'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_73_pypy
+- 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -25,7 +25,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_73_pypy
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
 zip_keys:
@@ -33,3 +35,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -1,9 +1,13 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,11 +25,14 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_73_pypy
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -1,19 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -21,11 +25,14 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -25,7 +25,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
 - linux-aarch64
 zip_keys:
@@ -33,3 +35,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -1,19 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -21,11 +25,14 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,19 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.23'
 pin_run_as_build:
@@ -22,10 +26,13 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -22,10 +22,13 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_73_pypy
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
 - osx-64
 zip_keys:
@@ -29,3 +31,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_73_pypy
+- 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 zip_keys:
@@ -29,3 +31,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -21,11 +21,14 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_73_pypy
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -22,10 +22,13 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,35 +1,34 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
@@ -29,3 +31,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
@@ -29,3 +31,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
@@ -29,3 +31,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
@@ -29,3 +31,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -1,19 +1,15 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
-c_compiler_version:
-- '15'
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '15'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- vs2019
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -21,11 +17,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -1,19 +1,15 @@
 c_compiler:
-- gcc
-c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 numpy:
 - '1.21'
 pin_run_as_build:
@@ -21,11 +17,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
-- linux-64
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -17,9 +17,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_73_pypy
+- 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -11,15 +11,18 @@ m2w64_c_compiler:
 m2w64_cxx_compiler:
 - m2w64-toolchain
 numpy:
-- '1.23'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
 target_platform:
 - win-64
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -17,9 +17,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,19 +1,15 @@
 c_compiler:
-- gcc
-c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 numpy:
 - '1.23'
 pin_run_as_build:
@@ -22,10 +18,11 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/README.md
+++ b/README.md
@@ -31,129 +31,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.21python3.10.____cpython</td>
+              <td>linux_64_numpy1.21python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.8.____73_pypy</td>
+              <td>linux_64_numpy1.21python3.8.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.8.____cpython</td>
+              <td>linux_64_numpy1.21python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.9.____73_pypy</td>
+              <td>linux_64_numpy1.21python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.21python3.9.____cpython</td>
+              <td>linux_64_numpy1.21python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.23python3.11.____cpython</td>
+              <td>linux_64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.21python3.10.____cpython</td>
+              <td>linux_aarch64_numpy1.21python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.21python3.8.____73_pypy</td>
+              <td>linux_aarch64_numpy1.21python3.8.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.8.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.21python3.8.____cpython</td>
+              <td>linux_aarch64_numpy1.21python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.21python3.9.____73_pypy</td>
+              <td>linux_aarch64_numpy1.21python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.21python3.9.____cpython</td>
+              <td>linux_aarch64_numpy1.21python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.23python3.11.____cpython</td>
+              <td>linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.10.____cpython</td>
+              <td>osx_64_numpy1.21python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.8.____73_pypy</td>
+              <td>osx_64_numpy1.21python3.8.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.8.____cpython</td>
+              <td>osx_64_numpy1.21python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.9.____73_pypy</td>
+              <td>osx_64_numpy1.21python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.9.____cpython</td>
+              <td>osx_64_numpy1.21python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.23python3.11.____cpython</td>
+              <td>osx_64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -185,45 +185,45 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.10.____cpython</td>
+              <td>win_64_numpy1.21python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.8.____73_pypy</td>
+              <td>win_64_numpy1.21python3.8.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.8.____cpython</td>
+              <td>win_64_numpy1.21python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.9.____73_pypy</td>
+              <td>win_64_numpy1.21python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.21python3.9.____cpython</td>
+              <td>win_64_numpy1.21python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.23python3.11.____cpython</td>
+              <td>win_64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 
 build:
   number: 1
+  # I don't understand why pypy 3.8 fails on aarch64, and it's
+  # not worth the effort to understand why.
+  skip: true  # [aarch64 and (python_impl == 'pypy') and (py==38)]
 
 outputs:
   - name: pytensor-base


### PR DESCRIPTION
Previously I merged despite a build failure, but this change keeps the CI green.

Deliberately not increasing build number since existing builds are up-to-date.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
