### PR TITLE
Only require blas when openblas is required

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,7 +98,7 @@ outputs:
         # For some reason we also need the "blas" package. Otherwise we get reports
         # of "cblas.h: No such file or directory" at import time.
         # Ref: <https://github.com/conda-forge/aesara-feedstock/issues/80>
-        - blas
+        - blas  # [not (linux64 or win64 or (osx and not arm64))]
     test:
       imports:
         - pytensor


### PR DESCRIPTION
Currently both mkl and openblas are required on linux/win64 because blas is always required.

This PR makes blas required in the same way as openblas.