### PR TITLE
Readd pypy aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
   - name: pytensor-base
     build:
       # NOTE: Keep this line synchronized with the identical one below.
-      skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
+      skip: true  # [py<39]
       script:
         - python -m pip install . --no-deps -vv
       entry_points:
@@ -72,7 +72,7 @@ outputs:
   - name: pytensor
     build:
       # NOTE: Keep this line synchronized with the identical one above.
-      skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
+      skip: true  # [py<39]
       script:
         - echo "Nothing to build here, just add dependencies."
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ outputs:
         - versioneer ==0.28                      # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - tomli                                  # [build_platform != target_platform]
+        - ninja                                  # [aarch64 and (python_impl == 'pypy')]
       host:
         - python
         - setuptools >=48.0.0
@@ -43,6 +44,7 @@ outputs:
         - versioneer ==0.28
         - pip
         - tomli
+        - ninja                                  # [aarch64 and (python_impl == 'pypy')]
       run:
         - python
         - setuptools >=48.0.0


### PR DESCRIPTION
Eventually readd PyPy on aarch64 when it starts working again. (It was disabled in #74.)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
