### PR TITLE
Move skip to individual outputs

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -43,11 +43,16 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_aarch64_numpy1.22python3.8.___hf1e1cf5873
-      linux_aarch64_numpy1.22python3.9.____cpythonpython_implpypy:
-        CONFIG: linux_aarch64_numpy1.22python3.9.____cpythonpython_implpypy
+      linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.22python3.9.___hfb96fafb35
+        SHORT_CONFIG: linux_aarch64_numpy1.22python3.9.___h7c5237695a
+      linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_aarch64_numpy1.22python3.9.___h23ece3e0d3
       linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython:
         CONFIG: linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.9.* *_73_pypy
 python_impl:
 - pypy
 target_platform:

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,0 +1,38 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/README.md
+++ b/README.md
@@ -80,10 +80,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.22python3.9.____cpythonpython_implpypy</td>
+              <td>linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____cpythonpython_implpypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18090&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pytensor-suite-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,11 @@ source:
 
 build:
   number: 0
-  skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
 
 outputs:
   - name: pytensor-base
     build:
+      skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
       script:
         - python -m pip install . --no-deps -vv
       entry_points:
@@ -70,6 +70,7 @@ outputs:
 
   - name: pytensor
     build:
+      skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
       script:
         - echo "Nothing to build here, just add dependencies."
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 outputs:
   - name: pytensor-base
     build:
+      # NOTE: Keep this line synchronized with the identical one below.
       skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
       script:
         - python -m pip install . --no-deps -vv
@@ -70,6 +71,7 @@ outputs:
 
   - name: pytensor
     build:
+      # NOTE: Keep this line synchronized with the identical one above.
       skip: true  # [(py<39) or (aarch64 and (python_impl == 'pypy'))]
       script:
         - echo "Nothing to build here, just add dependencies."


### PR DESCRIPTION
Closes #54 according to @mbargull's [suggestion](https://github.com/conda/conda-build/pull/5139).

The particular suggestion that seemed to work in this case was:

> or move the `skip` line to each output. 

In contrast, adding `# [python and ...` didn't seem to have any effect.

I tested this originally with the `main` branch of `conda-smithy` since that includes @mbargull's `conda-smithy` PR https://github.com/conda/conda-build/pull/5139 while the current release (`v3.30.4`) does not. But also testing with the current release I have been unable to reproduce the issue. Thus it seems that https://github.com/conda/conda-build/pull/5139 is unnecessary with this workaround.

Many thanks @mbargull!!! :heart:  This has been a major headache for many months now.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
