### PR TITLE
Fix dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ outputs:
         - {{ stdlib("c") }}
         - {{ compiler('cxx') }}
         - python                                 # [build_platform != target_platform]
-        - setuptools >=48.0.0                    # [build_platform != target_platform]
+        - setuptools >=59.0.0                    # [build_platform != target_platform]
         - cython                                 # [build_platform != target_platform]
         # Allow numpy pinnings to be managed by conda-forge global dependencies
         # See also <https://matrix.to/#/!SOyumkgPRWoXfQYIFH:matrix.org/$17156774815028VNLdj:matrix.org?via=matrix.org&via=gitter.im&via=salt-rock-lamp.ems.host>
@@ -40,7 +40,7 @@ outputs:
         - ninja                                  # [aarch64 and (python_impl == 'pypy')]
       host:
         - python
-        - setuptools >=48.0.0
+        - setuptools >=59.0.0
         - cython
         # Allow numpy pinnings to be managed by conda-forge global dependencies
         # See also <https://matrix.to/#/!SOyumkgPRWoXfQYIFH:matrix.org/$17156774815028VNLdj:matrix.org?via=matrix.org&via=gitter.im&via=salt-rock-lamp.ems.host>
@@ -52,7 +52,7 @@ outputs:
         - ninja                                  # [aarch64 and (python_impl == 'pypy')]
       run:
         - python
-        - setuptools >=48.0.0
+        - setuptools >=59.0.0
         - scipy >=0.14
         - filelock
         - etuples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,6 @@ outputs:
         - logical-unification
         - minikanren
         - cons
-        - typing_extensions
         - {{ pin_compatible("numpy") }}
 
     test:


### PR DESCRIPTION
# Don't merge directly

This is meant to be merged into the next version update.

I was mistakenly thinking that I could add a run_constrained so that if numba is installed then llvmlite would also be installed to mirror the numba dependency group. While I could make a new conda-forge package to achieve this, it would be a big pain for virtually zero gain. (The only benefit is if numba decouples from llvmlite, but we still need it when numba is installed.)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
