### PR TITLE
Use top-level build-skip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,11 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<310 or (osx and (not arm64) and py==313)]
 
 outputs:
   - name: pytensor-base
     build:
-      # NOTE: Keep this line synchronized with the identical one below.
-      skip: true  # [py<310 or (osx and (not arm64) and py==311)]
       script:
         - python -m pip install . --no-deps -vv
       entry_points:
@@ -73,8 +72,6 @@ outputs:
 
   - name: pytensor
     build:
-      # NOTE: Keep this line synchronized with the identical one above.
-      skip: true  # [py<310 or (osx and (not arm64) and py==311)]
       script:
         - echo "Nothing to build here, just add dependencies."
     requirements:


### PR DESCRIPTION
The output-specific skips don't seem to do anything anymore

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
