### PR TITLE
Set minimum required Python version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,3 @@
-{% set python_min = "3.11" %}
-
 schema_version: 1
 
 context:
@@ -37,7 +35,7 @@ outputs:
         - ${{ compiler('cxx') }}
         - if: build_platform != target_platform
           then:
-            - python {{ python_min }}
+            - python ==3.11.*
             - setuptools >=59.0.0
             - cython
             # Allow numpy pinnings to be managed by conda-forge global dependencies
@@ -47,7 +45,7 @@ outputs:
             - cross-python_${{ target_platform }}
             - tomli
       host:
-        - python {{ python_min }}
+        - python ==3.11.*
         - setuptools >=59.0.0
         - cython
         # Allow numpy pinnings to be managed by conda-forge global dependencies
@@ -57,7 +55,7 @@ outputs:
         - pip
         - tomli
       run:
-        - python >= {{ python_min }}
+        - python >=3.11
         - setuptools >=59.0.0
         - scipy >=1,<2
         - numpy >=2.0
@@ -92,9 +90,9 @@ outputs:
         - "echo \"Nothing to build here, just add dependencies.\""
     requirements:
       host:
-        - python {{ python_min }}
+        - python ==3.11.*
       run:
-        - python >= {{ python_min }}
+        - python >=3.11.*
         - ${{ pin_subpackage('pytensor-base', exact=True) }}
         - if: linux or win
           then: gxx


### PR DESCRIPTION
Trying to debug a `mamba install "pytensor=2.36.1"` I noticed that it tried to resolve ancient Python versions:

```
Looking for: ['pytensor=2.36.1']

conda-forge/win-64                                          Using cache
conda-forge/noarch                                          Using cache

Pinned packages:
  - python 3.12.*


warning  libmamba Added empty dependency for problem type SOLVER_RULE_UPDATE
Could not solve for environment specs
The following packages are incompatible
├─ msys2-conda-epoch is requested and can be installed;
└─ pytensor 2.36.1**  is not installable because there are no viable options
   ├─ pytensor 2.36.1 would require
   │  └─ gcc_win-64 14.* , which requires
   │     └─ gendef, which requires
   │        └─ libwinpthread >=12.0.0.r2.ggc561118da , which requires
   │           └─ msys2-conda-epoch <0.0a0 , which conflicts with any installable vers;       
   └─ pytensor 2.36.1 would require
      ├─ pytensor-base ==2.36.1 np2py314hb7a55bc_0, which requires
      │  └─ python with the potential options
      │     ├─ python [3.10.0|3.10.1|...|3.9.9], which can be installed;
      │     ├─ python [2.7.12|2.7.13|2.7.14|2.7.15] would require
      │     │  └─ vc 9.* , which does not exist (perhaps a missing channel);
      │     ├─ python 2.7.15 would require
      │     │  └─ vc >=9,<10.0a0 , which does not exist (perhaps a missing channel);
      │     ├─ python 3.4.5 would require
      │     │  └─ vc 10.* , which does not exist (perhaps a missing channel);
      │     ├─ python 3.4.5 would require
      │     │  └─ vs2010_runtime, which does not exist (perhaps a missing channel);
      │     └─ python [3.14.0rc1|3.14.0rc2|3.14.0rc3] would require
      │        └─ _python_rc, which does not exist (perhaps a missing channel);
      └─ python_abi 3.14.* *_cp314, which requires
         └─ python 3.14.* *_cp314, which conflicts with any installable versions previ.
```

Setting the minimum Python version (as described in https://conda-forge.org/docs/maintainer/knowledge_base/) should help the resolver by simplifying the dependency graph a lot(?).

Why do we call this file `recipe.yaml` and the documentation only speaks about `meta.yaml`?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
