### PR TITLE
Allow both accelerate and newaccelerate builds on osx-arm64

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
     - fix-mkl-blas-detection.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -110,7 +110,7 @@ outputs:
             - blas * mkl
             - mkl-service
         - if: osx and arm64
-          then: blas * accelerate
+          then: blas * *_*accelerate
         - if: not ((linux and x86_64) or win or osx)
           then: blas * openblas
       run_constraints:


### PR DESCRIPTION
Before it was impossible to install the `newaccelerate` variant of BLAS. Now we allow both `accelerate` and `newaccelerate` variants.

Note that `newaccelerate` requires MacOS >=13.3. With pixi, you must add the following to `pixi.toml`, to make `newaccelerate` installable.

```
[system-requirements]
macos = "13.3"
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
