### PR TITLE
Drop temporary mkl-service <2.7.1 pin

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
     - fix-mkl-blas-detection.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -108,11 +108,7 @@ outputs:
         - if: (linux and x86_64) or win or (osx and not arm64)
           then:
             - blas * mkl
-            # mkl-service 2.7.1 adds a `Requires-Dist: mkl` to its wheel
-            # metadata that conda-forge does not satisfy, so `pip check`
-            # in the tests below fails. Drop this pin once a fixed build
-            # ships via <https://github.com/conda-forge/mkl-service-feedstock/pull/53>.
-            - mkl-service <2.7.1
+            - mkl-service
         - if: osx and arm64
           then: blas * *accelerate
         - if: not ((linux and x86_64) or win or osx)


### PR DESCRIPTION
## Summary

- Upstream [IntelPython/mkl-service 2.7.2](https://github.com/IntelPython/mkl-service/releases/tag/2.7.2) reverted the `dependencies = ["mkl"]` line in `pyproject.toml` that was making downstream `pip check` fail (context: commit 2529114).
- conda-forge `mkl-service 2.7.2` is now available for all supported Python versions ([mkl-service-feedstock#54](https://github.com/conda-forge/mkl-service-feedstock/pull/54)), so CI is expected to pass without the workaround.
- Removes the temporary `mkl-service <2.7.1` run pin and bumps `build.number` to 1 so newly built pytensor artifacts no longer carry the pin in their run requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)